### PR TITLE
Remove `futures-util-preview` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,7 +912,6 @@ dependencies = [
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ trust-dns-client = { git = "https://github.com/bluejekyll/trust-dns" }
 trust-dns-resolver = { git = "https://github.com/bluejekyll/trust-dns" }
 structopt = "0.3.1"
 futures-preview = "0.3.0-alpha"
-futures-util-preview = "0.3.0-alpha"
 failure = "0.1.5"
 tokio = "0.2.0-alpha"
 rand = "0.7.2"

--- a/src/query.rs
+++ b/src/query.rs
@@ -6,8 +6,10 @@ use std::{
 
 use chrono::NaiveDateTime;
 use data_encoding::{Encoding, BASE32, BASE64, HEXLOWER};
-use futures::stream::{FuturesUnordered, Stream};
-use futures_util::FutureExt;
+use futures::{
+    stream::{FuturesUnordered, Stream},
+    FutureExt,
+};
 
 use trust_dns_client::rr::{
     self,


### PR DESCRIPTION
Turns out the `FuturesExt` trait is provided via `futures-preview` as
well.